### PR TITLE
Outlook no longer support Basic Authentication.

### DIFF
--- a/inc/Config.php
+++ b/inc/Config.php
@@ -73,10 +73,6 @@ class Config
                 'host' => 'smtp.europe.secureserver.net',
                 'port' => 25,
             ],
-            __('Hotmail', 'sy-mailer') => [
-                'host' => 'smtp-mail.outlook.com',
-                'port' => 587,
-            ],
             __('iCloud', 'sy-mailer') => [
                 'host' => 'smtp.mail.me.com',
                 'port' => 587,


### PR DESCRIPTION
Outlook.com requires the use of Modern Auth / OAuth2.  Basic auth is in the process of being deprecated from the Outlook.com service.

Authentication unsuccessful, basic authentication is disabled.